### PR TITLE
Update readme of quick start example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,18 +44,17 @@ template = '''
 '''
 
 
-def compute_matrix(threshold: float):
-    y_pred = [p[1] < threshold for p in prediction]
-    return confusion_matrix(y_true, y_pred).ravel()
-
-
 @app('/demo')
 async def serve(q: Q):
 
     # Get a threshold value if available or 0.5 by default
     threshold = q.args.slider if 'slider' in q.args else 0.5
-    tn, fp, fn, tp = compute_matrix(threshold)
 
+    # Compute confusion matrix
+    y_pred = [p[1] < threshold for p in prediction]
+    tn, fp, fn, tp = confusion_matrix(y_true, y_pred).ravel()
+
+    # Handle interaction
     if not q.client.initialized:  # First visit, create a card for the matrix
         q.page['matrix'] = ui.form_card(box='1 1 3 4', items=[
             ui.text(template.format(tn=tn, fp=fp, fn=fn, tp=tp)),


### PR DESCRIPTION
If PR merged, the `README.md` will be updated of quick start example. Example will take Titanic dataset, train a model, compute predictions and show the confusion matrix. You can set the threshold value for predictions similar to DAI:


https://user-images.githubusercontent.com/4668960/106767313-03ee8900-663b-11eb-9eea-599be2433c3e.mov

Any suggestions welcome. We can replace this example if not appropriate / fitting.

Resolves #2
