### PR TITLE
Improve naming/API, consistency and docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ from h2o_wave_ml import build_model, save_model
 
 train_set = './creditcard_train.csv'
 model = build_model(train_set, target_column='DEFAULT_PAYMENT_NEXT_MONTH')
-path = save_model(model, output_folder='./')
+path = save_model(model, output_dir_path='./')
 ```
 
 If model stored, we can load it up and make predictions:

--- a/h2o_wave_ml/__init__.py
+++ b/h2o_wave_ml/__init__.py
@@ -16,5 +16,5 @@
 Python package `h2o_wave_ml` provides the API functions for automatic machine learning tasks.
 """
 
-from .ml import (ModelEngine, ModelEngineType, ModelMetric, DataSourceObj,
+from .ml import (Model, ModelType, ModelMetric, DataSource,
                  build_model, get_model, save_model, load_model)


### PR DESCRIPTION
This PR includes more simplification, renaming, docs, etc.

Majorly, the `predict()` needs better design instead of the `DataSourceOb` and determining input by type.

Next steps before merging:
- Address TODOs in the source code.
- The readme.md needs a review to check if the examples/code are consistent with this refactoring.