### PR TITLE
Add a wine prediction example

### DIFF
--- a/examples/wine.py
+++ b/examples/wine.py
@@ -20,18 +20,21 @@ features = ['country', 'price', 'province', 'region_1', 'variety', 'winery']
 columns = {f: dt.unique(df[f]).to_list()[0] for f in features}
 choices = {key: [ui.choice(str(item)) for item in columns[key] if item] for key in columns}
 
+# Extract a default row
+default_row = df[2, :].to_dict()
+default_value = {key: cols[0] for key, cols in default_row.items()}
+
 
 @app('/demo')
 async def serve(q: Q):
 
     # Prepare feature values or use default ones
-    default_row = 2
-    country = q.args.country or df[default_row, 'country']
-    price = float(q.args.price) if q.args.price else df[default_row, 'price']
-    province = q.args.province or df[default_row, 'province']
-    region = q.args.region or df[default_row, 'region_1']
-    variety = q.args.variety or df[default_row, 'variety']
-    winery = q.args.winery or df[default_row, 'winery']
+    country = q.args.country or default_value['country']
+    price = float(q.args.price) if q.args.price else default_value['price']
+    province = q.args.province or default_value['province']
+    region = q.args.region or default_value['region_1']
+    variety = q.args.variety or default_value['variety']
+    winery = q.args.winery or default_value['winery']
 
     # Prepare input data and do the predictions
     input_data = [features, [country, price, province, region, variety, winery]]


### PR DESCRIPTION
If PR merged a new example will be added to our examples buffet:

![wine2](https://user-images.githubusercontent.com/4668960/109310717-3314a680-7845-11eb-9436-58f08d3308e9.gif)



# Notes
- [`spinbox`](https://h2oai.github.io/wave/docs/api/ui#spinbox) doesn't have `trigger` attribute so I was unable to use it.
- `dropbox` has, obviously, a limit to items which cause significant lag while clicked on it. A good feature to add would be filter to whittle down items. There is a similar problem in `QDB` and we use `picker` set to `max_choices=1` to have filter ability.
- Dataset used: https://www.kaggle.com/christopheiv/winemagdata130k

Thanks @johnygomez and @mturoci for help!