### PR TITLE
DriverlessAI integration

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,2 +1,3 @@
 h2o_wave
+h2o_wave_ml
 sklearn

--- a/h2o_wave_ml/__init__.py
+++ b/h2o_wave_ml/__init__.py
@@ -16,4 +16,4 @@
 Python package `h2o_wave_ml` provides the API functions for automatic machine learning tasks.
 """
 
-from .ml import Model, ModelType, ModelMetric, build_model, get_model, save_model, load_model
+from .ml import Model, ModelType, ModelMetric, TaskType, build_model, get_model, save_model, load_model

--- a/h2o_wave_ml/ml.py
+++ b/h2o_wave_ml/ml.py
@@ -225,6 +225,29 @@ class _DAIModel(Model):
             for col_i, name in enumerate(data[0])
         }
 
+    @staticmethod
+    def _extract_class(name: str) -> str:
+        """Extract a predicted class name from DAI column name.
+
+        Examples:
+            >>> _DAIModel._extract_class('target_column.class1')
+            'class1'
+        """
+
+        return name.split('.')[-1]
+
+    @classmethod
+    def _get_prediction_output(cls, df: dt.frame) -> List[Tuple]:
+        names = [cls._extract_class(name) for name in df.names]
+
+        ret = []
+        for i in range(df.nrows):
+            row = df[i, :].to_tuples()[0]
+            index = row.index(max(row))
+            ret.append(tuple([names[index], *row]))
+
+        return ret
+
     @classmethod
     def build(cls, file_path: str, target_column: str, model_metric: ModelMetric, task_type: Optional[TaskType],
               **kwargs) -> Model:
@@ -269,29 +292,6 @@ class _DAIModel(Model):
 
         dai = cls._get_instance()
         return _DAIModel(dai.experiments.get(experiment_id))
-
-    @staticmethod
-    def _extract_class(name: str) -> str:
-        """Extract a predicted class name from DAI column name.
-
-        Examples:
-            >>> _DAIModel._extract_class('target_column.class1')
-            'class1'
-        """
-
-        return name.split('.')[-1]
-
-    @classmethod
-    def _get_prediction_output(cls, df: dt.frame) -> List[Tuple]:
-        names = [cls._extract_class(name) for name in df.names]
-
-        ret = []
-        for i in range(df.nrows):
-            row = df[i, :].to_tuples()[0]
-            index = row.index(max(row))
-            ret.append(tuple([names[index], *row]))
-
-        return ret
 
     def predict(self, data: Optional[List[List]] = None, file_path: Optional[str] = None, **_kwargs) -> List[Tuple]:
         dai = self._get_instance()

--- a/h2o_wave_ml/ml.py
+++ b/h2o_wave_ml/ml.py
@@ -280,7 +280,7 @@ class _DAIModel(Model):
         ex = dai.experiments.create(
             train_dataset=dataset,
             target_column=target_column,
-            task=kwargs.get('_dai_task', task),
+            task=task,
             **params,
         )
 

--- a/h2o_wave_ml/ml.py
+++ b/h2o_wave_ml/ml.py
@@ -282,19 +282,14 @@ class _DAIModel(Model):
         return name.split('.')[-1]
 
     @classmethod
-    def _get_prediction_output(cls, f) -> List[Tuple]:
-        rows = f.to_tuples()
-        names = [cls._extract_class(name) for name in f.names]
+    def _get_prediction_output(cls, df: dt.frame) -> List[Tuple]:
+        names = [cls._extract_class(name) for name in df.names]
 
         ret = []
-        for row in rows:
-            max_value = row[0]
-            value_index = 0
-            for i, value in enumerate(row):
-                if value > max_value:
-                    max_value = value
-                    value_index = i
-            ret.append(tuple([names[value_index], *row]))
+        for i in range(df.nrows):
+            row = df[i, :].to_tuples()[0]
+            index = row.index(max(row))
+            ret.append(tuple([names[index], *row]))
 
         return ret
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     url='https://github.com/h2oai/wave-ml',
-    packages=setuptools.find_packages(exclude=("examples",)),
+    packages=setuptools.find_packages(exclude=('examples',)),
     classifiers=[
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
@@ -38,5 +38,6 @@ setuptools.setup(
     install_requires=[
         'datatable==0.11.1',
         'h2o==3.32.0.2',
+        'driverlessai',
     ]
 )


### PR DESCRIPTION
If PR is merged, `DAI` engine will be incorporated into the current codebase. Cloud integration will be delivered in different PR.

There are some topics worth mentioning with open questions:

## New argument to API

A new argument will be added to `build_model()` - `task_type`:

```python3
def build_model(
    file_path: str,
    target_column: str,
    model_metric: ModelMetric = ModelMetric.AUTO,
    task_type: Optional[TaskType] = None,
    model_type: Optional[ModelType] = None,
    **kwargs,
) -> Model:
```

The goal is to specify whether a prediction is of *classification* or *regression* type. It's determined automatically if not specified.

- Is the name of the argument appropriate? Currently, it's inherited from `DAI` client but feels ambiguous to me. Other names like `ml_task_type`, `problem_type` and `prediction_type` were considered.

## Optional `kwargs` arguments

There already were some undocumented arguments to `build_model()` function. This PR will extend these arguments and set the convention of naming. The arguments are: `_dai_time`, `_dai_time`, `_dai_interpretability`, `_h2o3_max_runtime_secs`, `_h2o3_max_models`. The documentation will be provided later.

Arguments are optional and function will not error out if an unknown argument is provided. Example of use:

```python3
model = build_model(dataset, target_column='points', _dai_time=1, _h2o3_max_runtime_secs=10)
```

- Is it ok to provide such specific arguments to underlying engines?
- Is the convention of underscore prefix alright? The goal is to mark arguments, so it's clear they affect engines directly.

## Resulting output from predictions

`H2O-3` and `DAI` have subtle discrepancies regarding the prediction output. `H2O-3` is providing a class on *classification* problem type. `DAI` doesn't.

The PR will include the missing class in predictions to unify the output. The class with maximum probability will be picked.

- Is it better to include the missing class or to drop it from `H2O-3` output?

## Notes

- `DAI` has a significant delay producing predictions comparing to `H2O-3`. Predicting on `DAI` takes 10-15 secs on a one row. `H2O-3` predictions feel instantaneous.
- `DAI` is not able to compute prediction on a one/few rows directly specifying the values. A temporary dataset is created and uploaded to `DAI` instead.

Resolves #8
Resolves #9
