### PR TITLE
feat: add steam support

### DIFF
--- a/h2o_wave_ml/ml.py
+++ b/h2o_wave_ml/ml.py
@@ -213,9 +213,7 @@ class _DAIModel(Model):
                                                     username=_config.dai_username,
                                                     password=_config.dai_password)
             elif _config.steam_address and _config.steam_refresh_token:
-                h2osteam.login(url=_config.steam_address,
-                               refresh_token=_config.steam_refresh_token,
-                               verify_ssl=False)
+                h2osteam.login(url=_config.steam_address, refresh_token=_config.steam_refresh_token)
                 instance = DriverlessClient.get_instance(name=_config.steam_instance_name)
                 if instance.status() == 'stopped':
                     raise RuntimeError('DAI instance is stopped')

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,6 @@ setuptools.setup(
         'datatable',
         'h2o==3.32.0.2',
         'driverlessai',
+        'h2osteam@https://enterprise-steam.s3.amazonaws.com/release/1.8.1/python/h2osteam-1.8.1-py2.py3-none-any.whl',
     ]
 )


### PR DESCRIPTION
This PR allows users to utilize a *DAI* instance if available on *Steam*:
- `H2O_WAVE_ML_STEAM_ADDRESS` needs to be specified in order to connect.
- `H2O_WAVE_ML_STEAM_REFRESH_TOKEN` needs to be copied from *Steam* interface to have access.
- `H2O_WAVE_ML_STEAM_INSTANCE_NAME` needs to be specified to identify an instance to use.

## Notes
- A Steam client of version 1.8.1 is added to the package dependencies.
- An error is raised if the instance is in `stopped` state.
- The PR does not include multinode handling.

Part of #10
