### PR TITLE
Add Pandas support

### DIFF
--- a/h2o_wave_ml/dai.py
+++ b/h2o_wave_ml/dai.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import csv
-import os
+from pathlib import Path
 import time
 from typing import Dict, Optional, List, Tuple, IO
 from urllib.parse import urljoin
@@ -105,10 +105,10 @@ def _encode_from_csv(csvfile: IO) -> Dict:
     }
 
 
-def _encode_from_pandas(pandas_df: PandasDataFrame) -> Dict:
+def _encode_from_pandas(df: PandasDataFrame) -> Dict:
     return {
-        'fields': list(pandas_df.columns),
-        'rows': [[str(item) for item in row] for _i, row in pandas_df.iterrows()]
+        'fields': list(df.columns),
+        'rows': [[str(item) for item in row] for _i, row in df.iterrows()]
     }
 
 
@@ -202,21 +202,24 @@ class _DAIModel(Model):
         return cls._INSTANCE
 
     @classmethod
-    def _build_model(cls, train_file_path: str, pandas_df: Optional[PandasDataFrame], target_column: str,
+    def _build_model(cls, train_file_path: str, train_df: Optional[PandasDataFrame], target_column: str,
                      model_metric: ModelMetric, task_type: Optional[TaskType], categorical_columns: Optional[List[str]],
                      feature_columns: Optional[List[str]], drop_columns: Optional[List[str]],
-                     validation_file_path: Optional[str], access_token: str, **kwargs):
+                     validation_file_path: str, validation_df: Optional[PandasDataFrame], access_token: str, **kwargs):
 
         dai = cls._get_instance(access_token)
 
         train_dataset_id = _make_id()
 
-        if train_file_path and os.path.exists(train_file_path):
-            train_dataset = dai.datasets.create(data=train_file_path, name=train_dataset_id)
-        elif pandas_df:
-            train_dataset = dai.datasets.create(data=pandas_df, name=train_dataset_id)
+        if train_file_path:
+            if Path(train_file_path).exists():
+                train_dataset = dai.datasets.create(data=train_file_path, name=train_dataset_id)
+            else:
+                raise ValueError('train file not found')
+        elif train_df:
+            train_dataset = dai.datasets.create(data=train_df, name=train_dataset_id)
         else:
-            raise ValueError('train frame not supplied')
+            raise ValueError('train data not supplied')
 
         try:
             train_summary = train_dataset.column_summaries(columns=[target_column])[0]
@@ -243,13 +246,18 @@ class _DAIModel(Model):
         if model_metric != ModelMetric.AUTO:
             params['scorer'] = model_metric.name
 
-        if validation_file_path is not None:
-            validation_dataset_id = _make_id()
-            validation_dataset = dai.datasets.create(validation_file_path, name=validation_dataset_id)
+        validation_dataset = None
+        if validation_file_path:
+            if Path(validation_file_path).exists():
+                validation_dataset = dai.datasets.create(data=validation_file_path, name=_make_id())
+            else:
+                raise ValueError('validation file not found')
+        elif validation_df:
+            validation_dataset = dai.datasets.create(data=validation_df, name=_make_id())
 
+        if validation_dataset is not None:
             if categorical_columns is not None:
                 validation_dataset.set_logical_types(column_types)
-
             params['validation_dataset'] = validation_dataset
 
         if feature_columns is not None:
@@ -318,27 +326,28 @@ class _DAIModel(Model):
         return statuses.deployment_status[0].scorer.score.url
 
     @classmethod
-    def build(cls, train_file_path: str, pandas_df: Optional[PandasDataFrame], target_column: str,
+    def build(cls, train_file_path: str, train_df: Optional[PandasDataFrame], target_column: str,
               model_metric: ModelMetric, task_type: Optional[TaskType], categorical_columns: Optional[List[str]],
               feature_columns: Optional[List[str]], drop_columns: Optional[List[str]],
-              validation_file_path: Optional[str], access_token: str, refresh_token: str, **kwargs) -> Model:
+              validation_file_path: str, validation_df: Optional[PandasDataFrame],
+              access_token: str, refresh_token: str, **kwargs) -> Model:
         """Builds DAI based model."""
 
         if refresh_token:
             access_token, refresh_token = _refresh_token(refresh_token, _config.oidc_provider_url,
                                                          _config.oidc_client_id, _config.oidc_client_secret)
 
-        experiment = cls._build_model(train_file_path=train_file_path, pandas_df=pandas_df, target_column=target_column,
+        experiment = cls._build_model(train_file_path=train_file_path, train_df=train_df, target_column=target_column,
                                       model_metric=model_metric, task_type=task_type,
                                       categorical_columns=categorical_columns, feature_columns=feature_columns,
                                       drop_columns=drop_columns, validation_file_path=validation_file_path,
-                                      access_token=access_token, **kwargs)
+                                      validation_df=validation_df, access_token=access_token, **kwargs)
 
         if refresh_token:
             access_token, refresh_token = _refresh_token(refresh_token, _config.oidc_provider_url,
                                                          _config.oidc_client_id, _config.oidc_client_secret)
         elif not access_token and not refresh_token:
-            raise ValueError('not token credentials for MLOps specified')
+            raise ValueError('no token credentials for MLOps')
 
         deployment_env = kwargs.get('_mlops_deployment_env', 'PROD')
         endpoint_url = cls._deploy_model(experiment, access_token, deployment_env)
@@ -378,12 +387,12 @@ class _DAIModel(Model):
         return _DAIModel(endpoint_url)
 
     def predict(self, data: Optional[List[List]] = None, file_path: str = '',
-                pandas_df: Optional[PandasDataFrame] = None, **kwargs) -> List[Tuple]:
+                train_df: Optional[PandasDataFrame] = None, **kwargs) -> List[Tuple]:
 
         if data is not None:
             payload = _encode_from_data(data)
-        elif pandas_df is not None:
-            payload = _encode_from_pandas(pandas_df)
+        elif train_df is not None:
+            payload = _encode_from_pandas(train_df)
         elif file_path:
             with open(file_path) as csvfile:
                 payload = _encode_from_csv(csvfile)

--- a/h2o_wave_ml/dai.py
+++ b/h2o_wave_ml/dai.py
@@ -387,12 +387,12 @@ class _DAIModel(Model):
         return _DAIModel(endpoint_url)
 
     def predict(self, data: Optional[List[List]] = None, file_path: str = '',
-                train_df: Optional[PandasDataFrame] = None, **kwargs) -> List[Tuple]:
+                test_df: Optional[PandasDataFrame] = None, **kwargs) -> List[Tuple]:
 
         if data is not None:
             payload = _encode_from_data(data)
-        elif train_df is not None:
-            payload = _encode_from_pandas(train_df)
+        elif test_df is not None:
+            payload = _encode_from_pandas(test_df)
         elif file_path:
             with open(file_path) as csvfile:
                 payload = _encode_from_csv(csvfile)

--- a/h2o_wave_ml/h2o3.py
+++ b/h2o_wave_ml/h2o3.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+from pathlib import Path
 from typing import Optional, List, Tuple
 
 import h2o
@@ -39,13 +39,13 @@ def _is_classification_task(frame: h2o.H2OFrame, target: str) -> bool:
 
 
 def _create_h2o3_frame(data: Optional[List[List]] = None, file_path: str = '',
-                       pandas_df: Optional[PandasDataFrame] = None) -> h2o.H2OFrame:
+                       df: Optional[PandasDataFrame] = None) -> h2o.H2OFrame:
     if data is not None:
         return h2o.H2OFrame(python_obj=data, header=1)
-    elif pandas_df is not None:
-        return h2o.H2OFrame(python_obj=pandas_df)
+    elif df is not None:
+        return h2o.H2OFrame(python_obj=df)
     elif file_path:
-        if os.path.exists(file_path):
+        if Path(file_path).exists():
             return h2o.import_file(file_path)
         else:
             raise ValueError('file not found')
@@ -111,22 +111,25 @@ class _H2O3Model(Model):
             cls._INIT = True
 
     @classmethod
-    def build(cls, train_file_path: str, pandas_df: Optional[PandasDataFrame], target_column: str,
+    def build(cls, train_file_path: str, train_df: Optional[PandasDataFrame], target_column: str,
               model_metric: ModelMetric, task_type: Optional[TaskType], categorical_columns: Optional[List[str]],
               feature_columns: Optional[List[str]], drop_columns: Optional[List[str]],
-              validation_file_path: Optional[str], **kwargs) -> Model:
+              validation_file_path: str, validation_df: Optional[PandasDataFrame], **kwargs) -> Model:
         """Builds an H2O-3 based model."""
 
         cls.ensure()
 
         id_ = _make_project_id()
 
-        if train_file_path and os.path.exists(train_file_path):
-            train_frame = h2o.import_file(train_file_path)
-        elif pandas_df:
-            train_frame = h2o.H2OFrame(python_obj=pandas_df)
+        if train_file_path:
+            if Path(train_file_path).exists():
+                train_frame = h2o.import_file(train_file_path)
+            else:
+                raise ValueError('train file not found')
+        elif train_df:
+            train_frame = h2o.H2OFrame(python_obj=train_df)
         else:
-            raise ValueError('train frame not supplied')
+            raise ValueError('train data not supplied')
 
         if target_column not in train_frame.columns:
             raise ValueError('target column not found')
@@ -162,19 +165,20 @@ class _H2O3Model(Model):
                         sort_metric=model_metric.name,
                         **params)
 
-        if validation_file_path is not None:
-            if os.path.exists(validation_file_path):
+        validation_frame = None
+        if validation_file_path:
+            if Path(validation_file_path).exists():
                 validation_frame = h2o.import_file(validation_file_path)
             else:
                 raise ValueError('validation file not found')
+        elif validation_df is not None:
+            validation_frame = h2o.H2OFrame(python_obj=validation_df)
 
-            if categorical_columns is not None:
-                for column in categorical_columns:
-                    validation_frame[column] = validation_frame[column].ascharacter().asfactor()
+        if validation_frame is not None and categorical_columns is not None:
+            for column in categorical_columns:
+                validation_frame[column] = validation_frame[column].ascharacter().asfactor()
 
-            aml.train(x=x, y=target_column, training_frame=train_frame, validation_frame=validation_frame)
-        else:
-            aml.train(x=x, y=target_column, training_frame=train_frame)
+        aml.train(x=x, y=target_column, training_frame=train_frame, validation_frame=validation_frame)
 
         if aml.leader is None:
             raise ValueError('no model available')
@@ -191,8 +195,8 @@ class _H2O3Model(Model):
         return _H2O3Model(aml.leader)
 
     def predict(self, data: Optional[List[List]] = None, file_path: str = '',
-                pandas_df: Optional[PandasDataFrame] = None, **kwargs) -> List[Tuple]:
-        input_frame = _create_h2o3_frame(data, file_path, pandas_df)
+                train_df: Optional[PandasDataFrame] = None, **kwargs) -> List[Tuple]:
+        input_frame = _create_h2o3_frame(data, file_path, train_df)
         output_frame = self.model.predict(input_frame)
         data = output_frame.as_data_frame(use_pandas=False, header=False)
         return _decode_from_frame(data)

--- a/h2o_wave_ml/h2o3.py
+++ b/h2o_wave_ml/h2o3.py
@@ -195,8 +195,8 @@ class _H2O3Model(Model):
         return _H2O3Model(aml.leader)
 
     def predict(self, data: Optional[List[List]] = None, file_path: str = '',
-                train_df: Optional[PandasDataFrame] = None, **kwargs) -> List[Tuple]:
-        input_frame = _create_h2o3_frame(data, file_path, train_df)
+                test_df: Optional[PandasDataFrame] = None, **kwargs) -> List[Tuple]:
+        input_frame = _create_h2o3_frame(data, file_path, test_df)
         output_frame = self.model.predict(input_frame)
         data = output_frame.as_data_frame(use_pandas=False, header=False)
         return _decode_from_frame(data)

--- a/h2o_wave_ml/ml.py
+++ b/h2o_wave_ml/ml.py
@@ -30,6 +30,7 @@ def build_model(*, target_column: str, train_file_path: str = '', train_df: Opti
                 access_token: str = '', refresh_token: str = '', **kwargs) -> Model:
     """Trains a model.
 
+    The function has to be called with `target_column` and `train_file_path` or `train_df` at least to be functionable.
     If `model_type` is not specified, it is inferred from the current environment. Defaults to an H2O-3 model.
 
     Args:

--- a/h2o_wave_ml/ml.py
+++ b/h2o_wave_ml/ml.py
@@ -19,21 +19,23 @@ import h2o
 from .config import _config
 from .dai import _DAIModel
 from .h2o3 import _H2O3Model
-from .types import Model, ModelMetric, ModelType, TaskType
+from .types import Model, ModelMetric, ModelType, TaskType, PandasDataFrame
 
 
-def build_model(train_file_path: str, *, target_column: str, model_metric: ModelMetric = ModelMetric.AUTO,
-                task_type: Optional[TaskType] = None, model_type: Optional[ModelType] = None,
-                categorical_columns: Optional[List[str]] = None, feature_columns: Optional[List[str]] = None,
-                drop_columns: Optional[List[str]] = None, validation_file_path: Optional[str] = None,
-                access_token: str = '', refresh_token: str = '', **kwargs) -> Model:
+def build_model(*, target_column: str, train_file_path: str = '', pandas_df: Optional[PandasDataFrame] = None,
+                model_metric: ModelMetric = ModelMetric.AUTO, task_type: Optional[TaskType] = None,
+                model_type: Optional[ModelType] = None, categorical_columns: Optional[List[str]] = None,
+                feature_columns: Optional[List[str]] = None, drop_columns: Optional[List[str]] = None,
+                validation_file_path: Optional[str] = None, access_token: str = '',
+                refresh_token: str = '', **kwargs) -> Model:
     """Trains a model.
 
     If `model_type` is not specified, it is inferred from the current environment. Defaults to an H2O-3 model.
 
     Args:
-        train_file_path: The path to the training dataset.
         target_column: The name of the target column (the column to be predicted).
+        train_file_path: The path to the training dataset.
+        pandas_df: Pandas DataFrame as a training set instead of file.
         model_metric: Optional evaluation metric to be used for modeling.
         task_type: Optional task type. Will be automatically determined if it's not specified.
         model_type: Optional model type.
@@ -100,20 +102,20 @@ def build_model(train_file_path: str, *, target_column: str, model_metric: Model
 
     if model_type is not None:
         if model_type == ModelType.H2O3:
-            return _H2O3Model.build(train_file_path, target_column, model_metric, task_type, categorical_columns,
-                                    feature_columns, drop_columns, validation_file_path, **kwargs)
+            return _H2O3Model.build(train_file_path, pandas_df, target_column, model_metric, task_type,
+                                    categorical_columns, feature_columns, drop_columns, validation_file_path, **kwargs)
         elif model_type == ModelType.DAI:
-            return _DAIModel.build(train_file_path, target_column, model_metric, task_type, categorical_columns,
-                                   feature_columns, drop_columns, validation_file_path, access_token, refresh_token,
-                                   **kwargs)
+            return _DAIModel.build(train_file_path, pandas_df, target_column, model_metric, task_type,
+                                   categorical_columns, feature_columns, drop_columns, validation_file_path,
+                                   access_token, refresh_token, **kwargs)
 
     if _config.dai_address or _config.steam_address:
-        return _DAIModel.build(train_file_path, target_column, model_metric, task_type, categorical_columns,
+        return _DAIModel.build(train_file_path, pandas_df, target_column, model_metric, task_type, categorical_columns,
                                feature_columns, drop_columns, validation_file_path, access_token, refresh_token,
                                **kwargs)
 
-    return _H2O3Model.build(train_file_path, target_column, model_metric, task_type, categorical_columns, feature_columns,
-                            drop_columns, validation_file_path, **kwargs)
+    return _H2O3Model.build(train_file_path, pandas_df, target_column, model_metric, task_type, categorical_columns,
+                            feature_columns, drop_columns, validation_file_path, **kwargs)
 
 
 def get_model(model_id: str = '', endpoint_url: str = '', model_type: Optional[ModelType] = None,

--- a/h2o_wave_ml/ml.py
+++ b/h2o_wave_ml/ml.py
@@ -44,7 +44,7 @@ def build_model(*, target_column: str, train_file_path: str = '', train_df: Opti
         feature_columns: Optional list of column names to be used for modeling.
         drop_columns: Optional list of column names to be dropped before modeling.
         validation_file_path: Optional path to a validation dataset.
-        validation_df: Optional DatataFrame to a validation dataset.
+        validation_df: Optional Pandas DataFrame as a validation dataset.
         access_token: Optional access token if engine needs to be authenticated.
         refresh_token: Optional refresh token if model needs to be authenticated.
         kwargs: Optional parameters to be passed to the model builder.

--- a/h2o_wave_ml/ml.py
+++ b/h2o_wave_ml/ml.py
@@ -22,12 +22,12 @@ from .h2o3 import _H2O3Model
 from .types import Model, ModelMetric, ModelType, TaskType, PandasDataFrame
 
 
-def build_model(*, target_column: str, train_file_path: str = '', pandas_df: Optional[PandasDataFrame] = None,
+def build_model(*, target_column: str, train_file_path: str = '', train_df: Optional[PandasDataFrame] = None,
                 model_metric: ModelMetric = ModelMetric.AUTO, task_type: Optional[TaskType] = None,
                 model_type: Optional[ModelType] = None, categorical_columns: Optional[List[str]] = None,
                 feature_columns: Optional[List[str]] = None, drop_columns: Optional[List[str]] = None,
-                validation_file_path: Optional[str] = None, access_token: str = '',
-                refresh_token: str = '', **kwargs) -> Model:
+                validation_file_path: str = '', validation_df: Optional[PandasDataFrame] = None,
+                access_token: str = '', refresh_token: str = '', **kwargs) -> Model:
     """Trains a model.
 
     If `model_type` is not specified, it is inferred from the current environment. Defaults to an H2O-3 model.
@@ -35,7 +35,7 @@ def build_model(*, target_column: str, train_file_path: str = '', pandas_df: Opt
     Args:
         target_column: The name of the target column (the column to be predicted).
         train_file_path: The path to the training dataset.
-        pandas_df: Pandas DataFrame as a training set instead of file.
+        train_df: Pandas DataFrame as a training set instead of file.
         model_metric: Optional evaluation metric to be used for modeling.
         task_type: Optional task type. Will be automatically determined if it's not specified.
         model_type: Optional model type.
@@ -43,6 +43,7 @@ def build_model(*, target_column: str, train_file_path: str = '', pandas_df: Opt
         feature_columns: Optional list of column names to be used for modeling.
         drop_columns: Optional list of column names to be dropped before modeling.
         validation_file_path: Optional path to a validation dataset.
+        validation_df: Optional DatataFrame to a validation dataset.
         access_token: Optional access token if engine needs to be authenticated.
         refresh_token: Optional refresh token if model needs to be authenticated.
         kwargs: Optional parameters to be passed to the model builder.
@@ -102,20 +103,21 @@ def build_model(*, target_column: str, train_file_path: str = '', pandas_df: Opt
 
     if model_type is not None:
         if model_type == ModelType.H2O3:
-            return _H2O3Model.build(train_file_path, pandas_df, target_column, model_metric, task_type,
-                                    categorical_columns, feature_columns, drop_columns, validation_file_path, **kwargs)
+            return _H2O3Model.build(train_file_path, train_df, target_column, model_metric, task_type,
+                                    categorical_columns, feature_columns, drop_columns, validation_file_path,
+                                    validation_df, **kwargs)
         elif model_type == ModelType.DAI:
-            return _DAIModel.build(train_file_path, pandas_df, target_column, model_metric, task_type,
+            return _DAIModel.build(train_file_path, train_df, target_column, model_metric, task_type,
                                    categorical_columns, feature_columns, drop_columns, validation_file_path,
-                                   access_token, refresh_token, **kwargs)
+                                   validation_df, access_token, refresh_token, **kwargs)
 
     if _config.dai_address or _config.steam_address:
-        return _DAIModel.build(train_file_path, pandas_df, target_column, model_metric, task_type, categorical_columns,
-                               feature_columns, drop_columns, validation_file_path, access_token, refresh_token,
-                               **kwargs)
+        return _DAIModel.build(train_file_path, train_df, target_column, model_metric, task_type, categorical_columns,
+                               feature_columns, drop_columns, validation_file_path, validation_df, access_token,
+                               refresh_token, **kwargs)
 
-    return _H2O3Model.build(train_file_path, pandas_df, target_column, model_metric, task_type, categorical_columns,
-                            feature_columns, drop_columns, validation_file_path, **kwargs)
+    return _H2O3Model.build(train_file_path, train_df, target_column, model_metric, task_type, categorical_columns,
+                            feature_columns, drop_columns, validation_file_path, validation_df, **kwargs)
 
 
 def get_model(model_id: str = '', endpoint_url: str = '', model_type: Optional[ModelType] = None,

--- a/h2o_wave_ml/types.py
+++ b/h2o_wave_ml/types.py
@@ -14,7 +14,13 @@
 
 import abc
 from enum import Enum
-from typing import Optional, List, Tuple
+from typing import Optional, List, Tuple, Any, Union
+
+try:
+    import pandas
+    PandasDataFrame = pandas.DataFrame
+except ModuleNotFoundError:
+    PandasDataFrame = Any
 
 
 class ModelMetric(Enum):
@@ -56,12 +62,14 @@ class Model(abc.ABC):
         """A Wave model engine type."""
 
     @abc.abstractmethod
-    def predict(self, data: Optional[List[List]] = None, file_path: str = '', **kwargs) -> List[Tuple]:
+    def predict(self, data: Optional[List[List]] = None, file_path: str = '',
+                pandas_df: Optional[PandasDataFrame] = None, **kwargs) -> List[Tuple]:
         """Returns the model's predictions for the given input rows.
 
         Args:
             data: A list of rows of column values. First row has to contain the column headers.
             file_path: The file path to the dataset.
+            pandas_df: Pandas DataFrame.
 
         Returns:
             A list of tuples representing predicted values.

--- a/h2o_wave_ml/types.py
+++ b/h2o_wave_ml/types.py
@@ -63,13 +63,13 @@ class Model(abc.ABC):
 
     @abc.abstractmethod
     def predict(self, data: Optional[List[List]] = None, file_path: str = '',
-                train_df: Optional[PandasDataFrame] = None, **kwargs) -> List[Tuple]:
+                test_df: Optional[PandasDataFrame] = None, **kwargs) -> List[Tuple]:
         """Returns the model's predictions for the given input rows.
 
         Args:
             data: A list of rows of column values. First row has to contain the column headers.
             file_path: The file path to the dataset.
-            train_df: Pandas DataFrame.
+            test_df: Pandas DataFrame.
 
         Returns:
             A list of tuples representing predicted values.

--- a/h2o_wave_ml/types.py
+++ b/h2o_wave_ml/types.py
@@ -14,7 +14,7 @@
 
 import abc
 from enum import Enum
-from typing import Optional, List, Tuple, Any, Union
+from typing import Optional, List, Tuple, Any
 
 try:
     import pandas
@@ -63,13 +63,13 @@ class Model(abc.ABC):
 
     @abc.abstractmethod
     def predict(self, data: Optional[List[List]] = None, file_path: str = '',
-                pandas_df: Optional[PandasDataFrame] = None, **kwargs) -> List[Tuple]:
+                train_df: Optional[PandasDataFrame] = None, **kwargs) -> List[Tuple]:
         """Returns the model's predictions for the given input rows.
 
         Args:
             data: A list of rows of column values. First row has to contain the column headers.
             file_path: The file path to the dataset.
-            pandas_df: Pandas DataFrame.
+            train_df: Pandas DataFrame.
 
         Returns:
             A list of tuples representing predicted values.


### PR DESCRIPTION
If PR merged, Pandas support will be enabled in Wave ML. Users will be able to use Pandas DataFrame to **train**, **validate**, and **test** without additional dependency to the project. A separate argument was used to supply the DataFrame: `train_df`, `test_df`, and `validate_df`.

The `build_model()` interface was changed, introducing a breaking change for the next version. Not quite happy how it turned out:

```python3
def build_model(*, target_column: str, train_file_path: str = '', train_df: Optional[PandasDataFrame] = None,
                model_metric: ModelMetric = ModelMetric.AUTO, task_type: Optional[TaskType] = None,
                model_type: Optional[ModelType] = None, categorical_columns: Optional[List[str]] = None,
                feature_columns: Optional[List[str]] = None, drop_columns: Optional[List[str]] = None,
                validation_file_path: str = '', validation_df: Optional[PandasDataFrame] = None,
                access_token: str = '', refresh_token: str = '', **kwargs) -> Model:
```

There is just one required argument (`target_column`), leaving the function a bit ambiguous regarding its usage. Docstring was updated to reflect this.

Asterisk was moved, so every argument has to be specified explicitly. This is because:
- there is no parameter following the function name obvious to its functionality. The `train_file_path` was a good choice but it's optional now.
- it leaves API open to changes.

## Notes
- Needs more testing.
- Just scoring was tested both on H2O-3 and DAI.

Part of #31