### PR TITLE
Update Steam handling

### DIFF
--- a/h2o_wave_ml/__init__.py
+++ b/h2o_wave_ml/__init__.py
@@ -23,5 +23,4 @@ __pdoc__ = {
     'config': False,
     'dai': False,
     'h2o3': False,
-    'utils': False,
 }

--- a/h2o_wave_ml/ml.py
+++ b/h2o_wave_ml/ml.py
@@ -47,7 +47,7 @@ def build_model(*, target_column: str, train_file_path: str = '', train_df: Opti
         validation_df: Optional Pandas DataFrame as a validation dataset.
         access_token: Optional access token if engine needs to be authenticated.
         refresh_token: Optional refresh token if model needs to be authenticated.
-        kwargs: Optional parameters to be passed to the model builder.
+        kwargs: Optional parameters to be passed to the model builder or Steam.
 
     Kwargs:
 
@@ -93,6 +93,15 @@ def build_model(*, target_column: str, train_file_path: str = '', train_df: Opti
         [*_h2o3_keep_cross_validation_fold_assignment*](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/algo-params/keep_cross_validation_fold_assignment.html)<br />
         *_h2o3_verbosity*<br />
         [*_h2o3_export_checkpoints_dir*](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/algo-params/export_checkpoints_dir.html)<br />
+
+        The list of the supported Steam options.
+
+        *_steam_dai_instance_name*<br />
+        *_steam_dai_multinode_name*<br />
+
+        The list of the supported MLOps options.
+
+        *_mlops_deployment_env*<br />
 
     Returns:
         The Wave model.

--- a/h2o_wave_ml/ml.py
+++ b/h2o_wave_ml/ml.py
@@ -47,11 +47,11 @@ def build_model(*, target_column: str, train_file_path: str = '', train_df: Opti
         validation_df: Optional Pandas DataFrame as a validation dataset.
         access_token: Optional access token if engine needs to be authenticated.
         refresh_token: Optional refresh token if model needs to be authenticated.
-        kwargs: Optional parameters to be passed to the model builder or Steam.
+        kwargs: Optional parameters to be passed to the model builder, Steam or MLOps.
 
     Kwargs:
 
-        The list of the supported DAI parameters. The description can be found [here](http://docs.h2o.ai/driverless-ai/pyclient/docs/html/client.html).
+        The list of the supported **DAI** parameters. The parameters description can be found [here](http://docs.h2o.ai/driverless-ai/pyclient/docs/html/client.html).
 
         *_dai_accuracy*<br />
         *_dai_time*<br />
@@ -70,7 +70,7 @@ def build_model(*, target_column: str, train_file_path: str = '', train_df: Opti
         *_dai_num_gap_periods*<br />
         *_dai_config_overrides*<br />
 
-        The list of the supported H2O-3 parameters. The description can be found [here](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/automl.html#required-parameters).
+        The list of the supported **H2O-3** parameters. The parameters description can be found [here](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/automl.html#required-parameters).
 
         [*_h2o3_max_runtime_secs*](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/algo-params/max_runtime_secs.html)<br />
         [*_h2o3_max_models*](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/algo-params/max_models.html)<br />
@@ -94,12 +94,12 @@ def build_model(*, target_column: str, train_file_path: str = '', train_df: Opti
         *_h2o3_verbosity*<br />
         [*_h2o3_export_checkpoints_dir*](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/algo-params/export_checkpoints_dir.html)<br />
 
-        The list of the supported Steam options.
+        The list of the supported **Steam** options.
 
         *_steam_dai_instance_name*<br />
         *_steam_dai_multinode_name*<br />
 
-        The list of the supported MLOps options.
+        The list of the supported **MLOps** options.
 
         *_mlops_deployment_env*<br />
 

--- a/h2o_wave_ml/utils.py
+++ b/h2o_wave_ml/utils.py
@@ -13,7 +13,17 @@
 # limitations under the License.
 
 import sys
+from typing import Tuple, Dict, List
 import uuid
+from urllib.parse import urljoin
+
+try:
+    import h2osteam
+except ModuleNotFoundError:
+    pass
+import requests
+
+from .config import _config
 
 
 def _make_id() -> str:
@@ -38,3 +48,83 @@ def _is_steam_imported() -> bool:
 
 def _is_mlops_imported() -> bool:
     return _is_package_imported('mlops')
+
+
+def _connect_to_steam(access_token: str = ''):
+
+    if not _is_steam_imported():
+        raise RuntimeError('no Steam package installed (install h2osteam)')
+
+    if _config.steam_refresh_token:
+        h2osteam.login(url=_config.steam_address, refresh_token=_config.steam_refresh_token,
+                       verify_ssl=_config.steam_verify_ssl)
+    elif access_token:
+        h2osteam.login(url=_config.steam_address, access_token=access_token,
+                       verify_ssl=_config.steam_verify_ssl)
+    else:
+        raise RuntimeError('no Steam credentials')
+
+
+def _refresh_token(refresh_token: str, provider_url: str, client_id: str, client_secret: str) -> Tuple[str, str]:
+
+    provider_url = f'{provider_url}/' if not provider_url.endswith('/') else provider_url
+    r = requests.get(urljoin(provider_url, '.well-known/openid-configuration'))
+    r.raise_for_status()
+    conf_data = r.json()
+
+    token_endpoint_url = conf_data['token_endpoint']
+
+    payload = dict(
+        client_id=client_id,
+        client_secret=client_secret,
+        grant_type='refresh_token',
+        refresh_token=refresh_token,
+    )
+    r = requests.post(token_endpoint_url, data=payload)
+    r.raise_for_status()
+    token_data = r.json()
+    return token_data['access_token'], token_data['refresh_token']
+
+
+def list_dai_instances(access_token: str = '', refresh_token: str = '') -> List[Dict]:
+    """Gets a list of all available Driverless instances.
+
+    A token is required to authenticate with Steam if `H2O_WAVE_ML_STEAM_REFRESH_TOKEN` is not set.
+
+    Args:
+        access_token: Optional access token to authenticate with Steam.
+        refresh_token: Optional refresh token to authenticate with Steam.
+
+    Returns:
+        A list of Driverless instances. The list contains a dictionary with `name`, `status` and `created_by` items.
+
+    """
+
+    if refresh_token:
+        access_token, refresh_token = _refresh_token(refresh_token, _config.oidc_provider_url,
+                                                     _config.oidc_client_id, _config.oidc_client_secret)
+    _connect_to_steam(access_token)
+    instances = h2osteam.api().get_driverless_instances()
+    return [{'name': i['name'], 'status': i['status'], 'created_by': i['created_by']} for i in instances]
+
+
+def list_dai_multinodes(access_token: str = '', refresh_token: str = '') -> List[str]:
+    """Gets a list of all available Driverless multinode instances.
+
+    A token is required to authenticate with Steam if `H2O_WAVE_ML_STEAM_REFRESH_TOKEN` is not set.
+
+    Args:
+        access_token: Optional access token to authenticate with Steam.
+        refresh_token: Optional refresh token to authenticate with Steam.
+
+    Returns:
+        A list of Driverless multinode instances.
+
+    """
+
+    if refresh_token:
+        access_token, refresh_token = _refresh_token(refresh_token, _config.oidc_provider_url,
+                                                     _config.oidc_client_id, _config.oidc_client_secret)
+    _connect_to_steam(access_token)
+    multinodes = h2osteam.api().get_driverless_multinodes()
+    return [m['name'] for m in multinodes]


### PR DESCRIPTION
If PR is merged, the user can specify Steam instance and Steam multinode as a parameter in `build_model()`: `_steam_dai_instance_name` and `_steam_dai_multinode_name`.

Two new user facing API functions will be available from `h2o_wave_ml.utils` to list the resources: `list_dai_instances()` and `list_dai_multinodes()`.

Part of #39