### PR TITLE
Improve metrics

### DIFF
--- a/h2o_wave_ml/dai.py
+++ b/h2o_wave_ml/dai.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import csv
+import warnings
 from pathlib import Path
 import time
 from typing import Dict, Optional, List, Tuple, IO
@@ -216,7 +217,10 @@ class _DAIModel(Model):
         }
 
         if model_metric != ModelMetric.AUTO:
-            params['scorer'] = model_metric.name
+            if 'scorer' not in params.get('scorer', []):
+                params['scorer'] = model_metric.name
+            else:
+                warnings.warn('the `dai_scorer` will be used instead of `model_metric`')
 
         validation_dataset = None
         if validation_file_path:

--- a/h2o_wave_ml/dai.py
+++ b/h2o_wave_ml/dai.py
@@ -120,6 +120,7 @@ class _DAIModel(Model):
         '_dai_accuracy',
         '_dai_time',
         '_dai_interpretability',
+        '_dai_scorer',
         '_dai_models',
         '_dai_transformers',
         '_dai_weight_column',

--- a/h2o_wave_ml/h2o3.py
+++ b/h2o_wave_ml/h2o3.py
@@ -79,6 +79,7 @@ class _H2O3Model(Model):
         '_h2o3_class_sampling_factors',
         '_h2o3_max_after_balance_size',
         '_h2o3_max_runtime_secs_per_model',
+        '_h2o3_stopping_metric',
         '_h2o3_stopping_tolerance',
         '_h2o3_stopping_rounds',
         '_h2o3_seed',
@@ -161,7 +162,6 @@ class _H2O3Model(Model):
         }
 
         aml = H2OAutoML(project_name=id_,
-                        stopping_metric=model_metric.name,
                         sort_metric=model_metric.name,
                         **params)
 

--- a/h2o_wave_ml/ml.py
+++ b/h2o_wave_ml/ml.py
@@ -51,11 +51,12 @@ def build_model(*, target_column: str, train_file_path: str = '', train_df: Opti
 
     Kwargs:
 
-        The list of the supported **DAI** parameters. The parameters description can be found [here](http://docs.h2o.ai/driverless-ai/pyclient/docs/html/client.html).
+        The list of the supported **DAI** parameters. The parameters description can be found [here](http://docs.h2o.ai/driverless-ai/pyclient/docs/html/client.html#driverlessai._experiments.Experiments.create).
 
         *_dai_accuracy*<br />
         *_dai_time*<br />
         *_dai_interpretability*<br />
+        *_dai_scorer*<br />
         *_dai_models*<br />
         *_dai_transformers*<br />
         *_dai_weight_column*<br />
@@ -79,6 +80,7 @@ def build_model(*, target_column: str, train_file_path: str = '', train_df: Opti
         [*_h2o3_class_sampling_factors*](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/algo-params/class_sampling_factors.html)<br />
         [*_h2o3_max_after_balance_size*](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/algo-params/max_after_balance_size.html)<br />
         [*_h2o3_max_runtime_secs_per_model*](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/algo-params/max_runtime_secs_per_model.html)<br />
+        [*_h2o3_stopping_metric*](https://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/algo-params/stopping_metric.html)<br />
         [*_h2o3_stopping_tolerance*](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/algo-params/stopping_tolerance.html)<br />
         [*_h2o3_stopping_rounds*](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/algo-params/stopping_rounds.html)<br />
         [*_h2o3_seed*](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/algo-params/seed.html)<br />

--- a/h2o_wave_ml/types.py
+++ b/h2o_wave_ml/types.py
@@ -28,16 +28,12 @@ class ModelMetric(Enum):
 
     AUTO = 1
     AUC = 2
-    MSE = 3
-    RMSE = 4
+    AUCPR = 3
+    LOGLOSS = 4
     MAE = 5
-    RMSLE = 6
-    DEVIANCE = 7
-    LOGLOSS = 8
-    AUCPR = 9
-    LIFT_TOP_GROUP = 10
-    MISCLASSIFICATION = 11
-    MEAN_PER_CLASS_ERROR = 12
+    MSE = 6
+    RMSE = 7
+    RMSLE = 8
 
 
 class ModelType(Enum):


### PR DESCRIPTION
This PR improves metrics in few ways:

* Default ModelMetrics limited to H2O-3 and DAI intersection and fixes #55 .
* `model_metric` can be used for all H2O-3 metrics (using AUTO for default ones).
* `stopping_metric` is anyway linked with `stopping_tolerance` and `stopping_rounds` so it makes sense to add it as a separate hyperparameter, typically users would fill all these 3 values or none of these 3.
* `dai_scorer` is added for any other DAI metric and this will also be required for #38 (Custom Scorers).
* A warning is shown if `model_metric` AND `dai_scorer` are provided and the `dai_scorer` is preferred because it is more specific (not sure if there's a better way of showing warning.
* Minor documentation updates.