### PR TITLE
Detect and force type to categorical for `H2O-3` predictions

### DIFF
--- a/h2o_wave_ml/h2o3.py
+++ b/h2o_wave_ml/h2o3.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import json
 from pathlib import Path
 import tempfile

--- a/h2o_wave_ml/ml.py
+++ b/h2o_wave_ml/ml.py
@@ -18,7 +18,7 @@ import h2o
 
 from .config import _config
 from .dai import _DAIModel
-from .h2o3 import _H2O3Model
+from .h2o3 import _H2O3Model, _get_categorical_columns
 from .types import Model, ModelMetric, ModelType, TaskType, PandasDataFrame
 
 
@@ -191,4 +191,5 @@ def load_model(file_path: str) -> Model:
     _H2O3Model.ensure()
 
     model = h2o.upload_model(path=file_path)
-    return _H2O3Model(model)
+    categorical_columns = _get_categorical_columns(model)
+    return _H2O3Model(model, categorical_columns)


### PR DESCRIPTION
If PR merged, *Wave ML* will inspect a model for categorical columns and force types for the test dataset. The model details are acquired using *H2O-3* `.save_model_details()` (which seems to be working only with files).

## Notes
I used examples from #45 to check if working properly (among the other checks).

Resolves #45 