### PR TITLE
Add function to download `autodoc`

### DIFF
--- a/h2o_wave_ml/h2o3.py
+++ b/h2o_wave_ml/h2o3.py
@@ -221,3 +221,7 @@ class _H2O3Model(Model):
     @property
     def endpoint_url(self) -> Optional[str]:
         return None
+
+    @property
+    def project_id(self) -> Optional[str]:
+        return None

--- a/h2o_wave_ml/types.py
+++ b/h2o_wave_ml/types.py
@@ -83,3 +83,8 @@ class Model(abc.ABC):
     @abc.abstractmethod
     def endpoint_url(self) -> Optional[str]:
         """An endpoint url for a deployed model, if any."""
+
+    @property
+    @abc.abstractmethod
+    def project_id(self) -> Optional[str]:
+        """An MLOps project id, if any."""

--- a/h2o_wave_ml/types.py
+++ b/h2o_wave_ml/types.py
@@ -87,4 +87,4 @@ class Model(abc.ABC):
     @property
     @abc.abstractmethod
     def project_id(self) -> Optional[str]:
-        """An MLOps project id, if any."""
+        """The MLOps project id, if any."""


### PR DESCRIPTION
If PR merged, two features will be added to *Wave ML*:

- New `utils.save_autodoc()` function will be available to save auto report.
- New `model.project_id` member will be available to identify the project in *MLOps*. This is not available for H2O-3 models, yet.

The `build_model()` for DAI models has been altered so the routine waits for `autodoc` to be ready before pushing to *MLOps*.

## Expected workflow

```python3
m = build_model()
file_name = utils.save_autodoc(project_id=m.project_id)
```

The `project_id` is available if the model is obtained by `get_model()` only if:
1. User used a `project_id` to retrieve the model.
2. User used an `endpoint_url` to retrieve the model and they own the project. This option might take some time.

Resolves #51
Resolves #61
