### PR TITLE
Remove MLOps related return types

### DIFF
--- a/h2o_wave_ml/dai.py
+++ b/h2o_wave_ml/dai.py
@@ -67,7 +67,7 @@ def _wait_for_deployment(mlops_client, deployment_id: str):
             raise RuntimeError('deployment timeout error')
 
 
-def _list_all_deployment_statuses(mlops_client) -> List[mlops.DeployDeploymentStatus]:
+def _list_all_deployment_statuses(mlops_client) -> List:  # -> List[mlops.DeployDeploymentStatus]:
     """Gets all user deployemnt statuses.
 
     NOTE: Function has long execution time. Might be worth to alter MLOps API.

--- a/h2o_wave_ml/utils.py
+++ b/h2o_wave_ml/utils.py
@@ -14,7 +14,7 @@
 
 from pathlib import Path
 import sys
-from typing import Tuple, Dict, List, Optional
+from typing import Tuple, Dict, List
 import uuid
 from urllib.parse import urljoin
 
@@ -133,7 +133,7 @@ def list_dai_multinodes(access_token: str = '', refresh_token: str = '') -> List
     return [m['name'] for m in multinodes]
 
 
-def _get_autodoc_artifact(mlops_client, model_id: str) -> Optional[mlops.StorageArtifact]:
+def _get_autodoc_artifact(mlops_client, model_id: str):  # -> Optional[mlops.StorageArtifact]:
     response = mlops_client.storage.artifact.list_entity_artifacts(
         mlops.StorageListEntityArtifactsRequest(entity_id=model_id))
     for artifact in response.artifact:


### PR DESCRIPTION
Return type annotation was causing errors when *MLOps* package was not present. This is because Wave ML can run both w/ and w/o MLOps client.

Thanks @vopani for catching this.